### PR TITLE
Use libc::c_char instead of i8 for char pointer casts

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -232,7 +232,7 @@ impl Document {
         // SAFETY: fy_document_build_from_string borrows the input - the String must
         // remain valid for the document's lifetime. We keep it in InputOwnership::OwnedString.
         let doc_ptr =
-            unsafe { fy_document_build_from_string(&cfg, s.as_ptr() as *const i8, s.len()) };
+            unsafe { fy_document_build_from_string(&cfg, s.as_ptr() as *const libc::c_char, s.len()) };
         if doc_ptr.is_null() {
             return Err(diag_error(diag, "fy_document_build_from_string failed"));
         }
@@ -289,7 +289,7 @@ impl Document {
         // SAFETY: fy_document_build_from_string borrows the input - the Vec must
         // remain valid for the document's lifetime. We keep it in InputOwnership::OwnedBytes.
         let doc_ptr = unsafe {
-            fy_document_build_from_string(&cfg, bytes.as_ptr() as *const i8, bytes.len())
+            fy_document_build_from_string(&cfg, bytes.as_ptr() as *const libc::c_char, bytes.len())
         };
         if doc_ptr.is_null() {
             return Err(diag_error(diag, "fy_document_build_from_string failed"));

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7,6 +7,7 @@ use crate::ffi_util::malloc_copy;
 use crate::node_ref::NodeRef;
 use fyaml_sys::*;
 
+use libc::c_char;
 use std::ptr::{self, NonNull};
 
 // =============================================================================
@@ -231,7 +232,7 @@ impl<'doc> Editor<'doc> {
             let parent_ptr = unsafe {
                 fy_node_by_path(
                     root_ptr,
-                    parent_path.as_ptr() as *const i8,
+                    parent_path.as_ptr() as *const c_char,
                     parent_path.len(),
                     0,
                 )
@@ -315,7 +316,7 @@ impl<'doc> Editor<'doc> {
             let pair_ptr = unsafe {
                 fy_node_mapping_lookup_pair_by_string(
                     parent_ptr,
-                    key.as_ptr() as *const i8,
+                    key.as_ptr() as *const c_char,
                     key.len(),
                 )
             };
@@ -329,7 +330,7 @@ impl<'doc> Editor<'doc> {
             } else {
                 // Create new key and append
                 let key_ptr = unsafe {
-                    fy_node_create_scalar_copy(self.doc_ptr(), key.as_ptr() as *const i8, key.len())
+                    fy_node_create_scalar_copy(self.doc_ptr(), key.as_ptr() as *const c_char, key.len())
                 };
                 if key_ptr.is_null() {
                     return Err(Error::Ffi("fy_node_create_scalar_copy failed"));
@@ -438,7 +439,7 @@ impl<'doc> Editor<'doc> {
             let pair_ptr = unsafe {
                 fy_node_mapping_lookup_pair_by_string(
                     parent_ptr,
-                    key.as_ptr() as *const i8,
+                    key.as_ptr() as *const c_char,
                     key.len(),
                 )
             };
@@ -547,7 +548,7 @@ impl<'doc> Editor<'doc> {
     /// The scalar style is automatically determined based on content.
     /// Use [`build_from_yaml`](Self::build_from_yaml) for explicit quoting.
     pub fn build_scalar(&mut self, value: &str) -> Result<RawNodeHandle> {
-        self.build_scalar_raw(value.as_ptr() as *const i8, value.len())
+        self.build_scalar_raw(value.as_ptr() as *const c_char, value.len())
     }
 
     /// Builds an empty sequence node.
@@ -666,7 +667,7 @@ impl<'doc> Editor<'doc> {
     ///
     /// For example, `set_tag(&mut node, "!custom")` produces `!custom value`.
     pub fn set_tag(&mut self, node: &mut RawNodeHandle, tag: &str) -> Result<()> {
-        let ret = unsafe { fy_node_set_tag(node.as_ptr(), tag.as_ptr() as *const i8, tag.len()) };
+        let ret = unsafe { fy_node_set_tag(node.as_ptr(), tag.as_ptr() as *const c_char, tag.len()) };
         if ret != 0 {
             return Err(Error::Ffi("fy_node_set_tag failed"));
         }
@@ -718,7 +719,7 @@ impl<'doc> Editor<'doc> {
             return Ok(root_ptr);
         }
         let node_ptr =
-            unsafe { fy_node_by_path(root_ptr, path.as_ptr() as *const i8, path.len(), 0) };
+            unsafe { fy_node_by_path(root_ptr, path.as_ptr() as *const c_char, path.len(), 0) };
         if node_ptr.is_null() {
             return Err(Error::Ffi("path not found"));
         }

--- a/src/node_ref.rs
+++ b/src/node_ref.rs
@@ -260,7 +260,7 @@ impl<'doc> NodeRef<'doc> {
     /// ```
     pub fn at_path(&self, path: &str) -> Option<NodeRef<'doc>> {
         let node_ptr =
-            unsafe { fy_node_by_path(self.as_ptr(), path.as_ptr() as *const i8, path.len(), 0) };
+            unsafe { fy_node_by_path(self.as_ptr(), path.as_ptr() as *const libc::c_char, path.len(), 0) };
         NonNull::new(node_ptr).map(|nn| NodeRef::new(nn, self.doc))
     }
 
@@ -344,7 +344,7 @@ impl<'doc> NodeRef<'doc> {
             return None;
         }
         let node_ptr = unsafe {
-            fy_node_mapping_lookup_by_string(self.as_ptr(), key.as_ptr() as *const i8, key.len())
+            fy_node_mapping_lookup_by_string(self.as_ptr(), key.as_ptr() as *const libc::c_char, key.len())
         };
         NonNull::new(node_ptr).map(|nn| NodeRef::new(nn, self.doc))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -172,7 +172,7 @@ impl FyParser {
             return Err(Error::Io("dup(stdin) failed"));
         }
 
-        let fp = unsafe { libc::fdopen(dup_fd, b"r\0".as_ptr() as *const i8) };
+        let fp = unsafe { libc::fdopen(dup_fd, b"r\0".as_ptr() as *const libc::c_char) };
         if fp.is_null() {
             unsafe { libc::close(dup_fd) };
             return Err(Error::Io("fdopen failed"));
@@ -187,7 +187,7 @@ impl FyParser {
         }
 
         let ret = unsafe {
-            fy_parser_set_input_fp(parser.inner.as_ptr(), b"stdin\0".as_ptr() as *const i8, fp)
+            fy_parser_set_input_fp(parser.inner.as_ptr(), b"stdin\0".as_ptr() as *const libc::c_char, fp)
         };
         if ret != 0 {
             unsafe { libc::fclose(fp) };


### PR DESCRIPTION
On ARM64 Linux, C `char` is unsigned (u8), so the fyaml-sys bindings emit `*const u8` for `const char *` parameters. However on x86 the C `char` is signed so an i8 is used instead. This is fine, but it means fyaml fails to compile on aarch64-unknown-linux-musl.

This is fixed by replacing all `as *const i8` with `as *const libc::c_char` (= i8 on x86_64, u8 on aarch64) so the casts match the platform-appropriate type produced by bindgen, enabling builds on both architectures.